### PR TITLE
Add github action for release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,47 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    name: Build and Release for Multiple OS
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Build for Windows
+        run: |
+          GOOS=windows GOARCH=amd64 go build -o webcurl.exe
+          zip -j webcurl-windows.zip webcurl.exe index.html tool.html
+
+      - name: Build for Linux
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o webcurl
+          zip -j webcurl-linux.zip webcurl index.html tool.html
+
+      - name: Build for macOS
+        run: |
+          GOOS=darwin GOARCH=amd64 go build -o webcurl
+          zip -j webcurl-macos.zip webcurl index.html tool.html
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: |
+            webcurl-windows.zip
+            webcurl-linux.zip
+            webcurl-macos.zip


### PR DESCRIPTION
添加GitHub Action配置文件，在创建标签时自动构建release文件，方便直接下载使用

<img width="1526" height="642" alt="image" src="https://github.com/user-attachments/assets/76509ee2-3635-4f15-a864-57f26580dbc1" />
